### PR TITLE
Add packaging and publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,3 +31,45 @@ jobs:
           user: __token__
           password: ${{ secrets.GITHUB_TOKEN }}
           repository-url: https://pypi.pkg.github.com/${{ github.repository_owner }}
+      - name: Bump version in pyproject.toml
+        id: bump_version
+        run: |
+          pip install toml
+          python -c "
+            import os
+            import toml
+            from pathlib import Path
+
+            pyproject = Path('pyproject.toml')
+            data = toml.load(pyproject)
+            version = data['project']['version']
+            major, minor, patch = map(int, version.split('.'))
+
+            ref = os.environ.get('GITHUB_REF', '')
+            if ref.startswith('refs/heads/version/'):
+                patch += 1
+                new_version = f'{major}.{minor}.{patch}'
+            else:
+                minor += 1
+                new_version = f'{major}.{minor}.0'
+
+            data['project']['version'] = new_version
+            with pyproject.open('w') as f:
+                toml.dump(data, f)
+            print(f'::set-output name=new_version::{new_version}')
+            "
+      
+      - name: Commit and push version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "Bump version to ${{ steps.bump_version.outputs.new_version }}"
+          git push
+
+      - name: Create branch for new version if on main
+        if: github.ref == 'refs/heads/main'
+        run: |
+          version=${{ steps.bump_version.outputs.new_version }}
+          git checkout -b version/${version}
+          git push origin version/${version}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,9 @@ name: Build and Publish
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
+    branches:
+      - main
+      - release/*
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Build and Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Build package
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish to GitHub Packages
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.GITHUB_TOKEN }}
+          repository-url: https://pypi.pkg.github.com/${{ github.repository_owner }}

--- a/README.md
+++ b/README.md
@@ -17,17 +17,7 @@ After installation the `triplifier` command is available to run the tool.
 * Soest J van, Choudhury A, Gaikwad N, Sloep M, Dumontier M, Dekker A (2019) [Annotation of Existing Databases using Semantic Web Technologies: Making Data more FAIR.](http://ceur-ws.org/Vol-2849/#paper-11) CEUR-WS, Edinburgh, pp 94–101
 
 
-## Prerequisites
-
-This tool can be executed in two modes:
-
-* Stand-alone java runnable jar
-* Docker container (and service) mode
-
-For the runnable jar, it needs a computer with [Java 8 runtime](oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html) installed.
-For the docker container, it needs [Docker Community Edition](https://www.docker.com/community-edition) (native on Ubuntu, "for Windows" or "for Mac").
-
-## Run as Java command-line tool
+## Run as command-line tool
 
 The basic configuration for the Python port can be run with the following command:
 
@@ -45,28 +35,10 @@ db:
   password: pass
 ```
 
-### Upload triples to RDF endpoint
-
-To upload data directly into an RDF endpoint (and hence save the memory footprint), please add the following variables in the YAML file (default: triplifier.yaml):
-
-* *repo.type*: Indicating the type of RDF endpoint. The following values are allowed for this variable:
-    * "memory": this is the default, in-memory (and file-based) RDF/OWL output
-    * "sparql": upload the triples directly in a SPARQL endpoint using the SPARQL protocol
-    * "rdf4j": upload the triples directly in an RDF4j repository (e.g. a RDF4j or GraphDB database)
-* *repo.url*: the URL of the RDF endpoint (not applicable or needed for `repo.type = memory`). In case of a SPARQL endpoint, include the URL of the actual SPARQL endpoint. In case of RDF4j, indicate the URL of the repository server
-* *repo.id*: for `repo.type = rdf4j` indicate the repository ID
-* *repo.user*: optional, specify the username for password-protected rdf4j repositories
-* *repo.pass*: optional, specify the password for password-protected rdf4j repositories
-
-An example of the full specification is given below:
-
+**Postgres database file**
 ```yaml
-repo:
-  type: rdf4j
-  url: http://localhost:7200
-  id: data
-  user: userNameTest
-  pass: test
+db:
+  url: "postgresql://postgres:postgres@localhost:5432/my_database"
 ```
 
 ### Optional arguments
@@ -82,42 +54,6 @@ By default, the tool will generate an ontology file (ontology.owl) and a turtle 
 The `--ontologyAndOrData` option allows running only the ontology extraction
 (`ontology`) or only the data materialization (`data`) given an ontology file.
 If omitted, both steps are executed.
-
-## Run as Docker container
-
-To run the triplifier as Docker container, you can run the following command:
-
-**On Linux/Unix/macOS systems:**
- ```
-docker run --rm \
-    -v $(pwd)/output.ttl:/output.ttl \
-    -v $(pwd)/ontology.owl:/ontology.owl \
-    -v $(pwd)/triplifier.yaml:/triplifier.yaml \
-    ghcr.io/maastrichtu-cds/triplifier:latest
- ```
-
- **On windows systems:**
- ```
-docker run --rm ^
-    -v %cd%/output.ttl:/output.ttl ^
-    -v %cd%/ontology.owl:/ontology.owl ^
-    -v %cd%/triplifier.yaml:/triplifier.yaml ^
-    ghcr.io/maastrichtu-cds/triplifier:latest
- ```
-
- ### Run as a service
-
- The example below shows how to run the container as a service, where the materialization process is called every interval time (defined by `SLEEPTIME` in seconds).
-
- ```
-docker run --rm \
-    -e SLEEPTIME=10 \
-    --link graphdb:graphdb \
-    -v $(pwd)/triplifier.yaml:/triplifier.yaml \
-    ghcr.io/maastrichtu-cds/triplifier:latest
- ```
-
-In this example, there is already a GraphDB docker container running, hence we can connect the docker containers. Therefore, the `repo.url` in the configuration file should contain the hostname "graphdb", as inserted by the `--link` option. If the endpoint is running at a different location, you can specify the full URL of that location in the configuration file, and omit the `--link` option.
  
  ## Annotations using the result
  An example of annotations (and insertions) can be found in the following repository:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 This repository creates the tooling project for the Triplifier.
 
+## Python package
+
+The Python code is packaged for distribution. You can install it from GitHub Packages:
+
+```bash
+pip install --extra-index-url https://pypi.pkg.github.com/<OWNER> triplifier
+```
+
+After installation the `triplifier` command is available to run the tool.
+
+
 ## References
 * Soest J van, Choudhury A, Gaikwad N, Sloep M, Dumontier M, Dekker A (2019) [Annotation of Existing Databases using Semantic Web Technologies: Making Data more FAIR.](http://ceur-ws.org/Vol-2849/#paper-11) CEUR-WS, Edinburgh, pp 94–101
 
@@ -21,7 +32,7 @@ For the docker container, it needs [Docker Community Edition](https://www.docker
 The basic configuration for the Python port can be run with the following command:
 
 ```
-python -m pythonTool.main_app -c triplifier.yaml
+triplifier -c triplifier.yaml
 ```
 
 The YAML configuration file contains the database connection information using SQLAlchemy style URLs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "triplifier"
-version = "0.1.0"
+version = "2.0.0"
 description = "Python port of the Triplifier tool."
 readme = "README.md"
 requires-python = ">=3.8"
 license = {file = "LICENSE"}
-authors = [ {name = "Triplifier Maintainers"} ]
+authors = [ {name = "Johan van Soest"} ]
 dependencies = [
     "rdflib>=6.0.0",
     "PyYAML>=5.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "triplifier"
+version = "0.1.0"
+description = "Python port of the Triplifier tool."
+readme = "README.md"
+requires-python = ">=3.8"
+license = {file = "LICENSE"}
+authors = [ {name = "Triplifier Maintainers"} ]
+dependencies = [
+    "rdflib>=6.0.0",
+    "PyYAML>=5.3",
+    "SQLAlchemy>=1.4",
+    "psycopg2-binary>=2.8"
+]
+
+[project.scripts]
+triplifier = "pythonTool.main_app:main"
+
+[tool.setuptools.packages.find]
+include = ["pythonTool*"]

--- a/pythonTool/__init__.py
+++ b/pythonTool/__init__.py
@@ -1,4 +1,4 @@
 """Python port of the Triplifier tool."""
 
 __all__ = ["db_inspector", "foreign_key_specification", "main_app", "rdf"]
-__version__ = "0.1.0"
+__version__ = "2.0.0"

--- a/pythonTool/__init__.py
+++ b/pythonTool/__init__.py
@@ -1,1 +1,4 @@
 """Python port of the Triplifier tool."""
+
+__all__ = ["db_inspector", "foreign_key_specification", "main_app", "rdf"]
+__version__ = "0.1.0"

--- a/test.sh
+++ b/test.sh
@@ -16,7 +16,7 @@ echo "db:" > test.yaml
 echo "  url: \"postgresql://postgres:postgres@localhost:5432/my_database\"" >> test.yaml
 
 # Run the Python tool with the test configuration file
-time python -m pythonTool.main_app -c test.yaml
+time triplifier -c test.yaml
 
 # Check if the tool ran successfully
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Summary
- package the Python source using a `pyproject.toml`
- expose a `triplifier` CLI command
- document package installation
- update scripts to use the new CLI
- add GitHub Actions workflow to build and upload the wheel to GitHub Packages

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python -m build` *(fails: No module named build)*

------
https://chatgpt.com/codex/tasks/task_e_6849433448c0832eafd2005b6058e291